### PR TITLE
Release Actions workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y git
+          git --version
           git config --global user.name GitHub
           git config --global user.email github@github.com
           pip install pipenv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-linux-x86_64:
+    name: Build Linux x86_64 Binary
+    runs-on: ubuntu-18.04
+    container:
+      image: python:3.7.4-slim-buster
+    steps:
+      - name: Build Binary
+        run: |
+          pip install pipenv
+          pipenv sync --dev
+          pipenv run inv build
+
+      - name: Upload Binary
+        uses: actions/upload-artifact@v1
+        with:
+          name: asgard-Linux-x86_64
+          path: dist/asgard
+
+  release:
+    name: Release
+    needs:
+      - build-linux-x86_64
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Download Binary (Linux-x86_64)
+        uses: actions/download-artifact@v1
+        with:
+          name: asgard-Linux-x86_64
+          path: dist/asgard-Linux-x86_64
+
+      - name: Upload Release Asset (Linux-x86_64)
+        id: upload-release-asset-linux-x86_64
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/asgard-Linux-x86_64
+          asset_name: asgard-Linux-x86_64
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*
 
+env:
+  PIPENV_NOSPIN: "true"
+
 jobs:
   build-linux-x86_64:
     name: Build Linux x86_64 Binary

--- a/tasks.py
+++ b/tasks.py
@@ -27,9 +27,10 @@ def test(c):
 
 
 @task
-def package(c):
+def build(c, docker=False):
     sh("pyinstaller asgard.spec")
-    sh(f"docker build --pull --tag {DOCKER_REPO}:{VERSION} .")
+    if docker:
+        sh(f"docker build --pull --tag {DOCKER_REPO}:{VERSION} .")
 
 
 @task


### PR DESCRIPTION
This adds the "Release" workflow, which is triggered on tag pushes. Currently, a Linux-x86_64 static binary will be uploaded as an asset to a GitHub release.

In the future, Docker images, Windows and Darwin binaries will be added. Possibly also a brew package.